### PR TITLE
Fix for issue #3 - SSL failure message

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -67,4 +67,7 @@ Pull the tags trough the [Repository Refs API](http://develop.github.com/p/repo.
 
 Publish the update details to the `response` array in the `update_themes` transient, similar to how [Wordpress updates themes](http://core.trac.wordpress.org/browser/trunk/wp-includes/update.php?rev=17978#L188).
 
+## Changelog
 
+### v1.3.4 - February 8, 2012
+* Fix to [SSL issue](https://github.com/UCF/Theme-Updater/issues/3). Code by Github user bainternet. Added by Github user danyork.

--- a/updater.php
+++ b/updater.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/UCF/Theme-Updater
 Description: A theme updater for GitHub hosted Wordpress themes.  This Wordpress plugin automatically checks GitHub for theme updates and enables automatic install.  For more information read <a href="https://github.com/UCF/Theme-Updater/blob/master/readme.markdown">plugin documentation</a>.
 Author: Douglas Beck
 Author: UCF Web Communications
-Version: 1.3.3
+Version: 1.3.4
 */
 
 require_once('assets.php');
@@ -127,4 +127,15 @@ function upgrader_source_selection_filter($source, $remote_source=NULL, $upgrade
 		}
 	}
 	return $source;
+}
+
+/*
+   Function to address the issue that users in a standalone WordPress installation
+   were receiving SSL errors and were unable to install themes.
+   https://github.com/UCF/Theme-Updater/issues/3
+*/
+add_action('http_request_args', 'no_ssl_http_request_args', 10, 2);
+function no_ssl_http_request_args($args, $url) {
+$args['sslverify'] = false;
+return $args;
 }


### PR DESCRIPTION
This pull request is for a fix for issue #3 about the SSL failure message.  The code is from @bainternet in his comment on the issue ( https://github.com/UCF/Theme-Updater/issues/3#issuecomment-3811068 )

I have tested this on one of my sites where the plugin was failing before and can confirm it now works.

I also added a "Changelog" section to the readme.markdown file to track changes like this (unless you want to create a separate changelog file).

Finally, I bumped up the version number to 1.3.4.  If you folks agree with this change and can merge it in and update the plugin on the WordPress.org site, that would be excellent as I have a situation where I want to use this plugin on a number of sites to reference a theme stored on Github.

Thanks for the consideration.
