### PR TITLE
Point people toward github-update project

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
 # No Longer Supported
 
-Since we are no longer supporting this plugin please feel free to look at one of the many forks for possible updates and fixes. If you are couragous enough you can fork this project and upgrade it as needed. Thanks
+We are no longer supporting this plugin. We recommend [github-update](https://github.com/afragen/github-updater) instead. It will update plugins as well as themes, and has many other useful features, including support for both public and private Github/BitBucket repositories. 
 
 # Wordpress plugin: a theme updater for GitHub-hosted Wordpress themes
 


### PR DESCRIPTION
Now that this is deprecated, make it so people who stumble across it (like myself) don't have to spend time hunting for a suitable replacement... I'm not personally affiliated with github-update in any way, I just spend some time looking around for a replacement and this seems to be by far the most full-featured and actively maintained replacement
